### PR TITLE
Fix calls to Term::Reader

### DIFF
--- a/src/prompt/enum_list.cr
+++ b/src/prompt/enum_list.cr
@@ -208,7 +208,7 @@ module Term
       # Count how many screen lines the question spans
       def question_lines_count(question_lines)
         question_lines.reduce(0) do |acc, line|
-          acc + @prompt.count_screen_lines(line)
+          acc + @prompt.count_screen_lines(line, Term::Screen.width)
         end
       end
 

--- a/src/prompt/list.cr
+++ b/src/prompt/list.cr
@@ -345,7 +345,7 @@ module Term
       # size how many screen lines the question spans
       private def question_lines_size(question_lines)
         question_lines.reduce(0) do |acc, line|
-          acc + @prompt.count_screen_lines(line)
+          acc + @prompt.count_screen_lines(line, Term::Screen.width)
         end
       end
 

--- a/src/prompt/mask_question.cr
+++ b/src/prompt/mask_question.cr
@@ -66,7 +66,7 @@ module Term
         until @done_masked
           @prompt.read_keypress
           question = render_question
-          total_lines = @prompt.count_screen_lines(question)
+          total_lines = @prompt.count_screen_lines(question, Term::Screen.width)
           @prompt.print(@prompt.clear_lines(total_lines))
           @prompt.print(render_question)
         end

--- a/src/prompt/question.cr
+++ b/src/prompt/question.cr
@@ -104,7 +104,7 @@ module Term
 
           question =  render_question
           input_line = question + result.value.to_s
-          total_lines = @prompt.count_screen_lines(input_line)
+          total_lines = @prompt.count_screen_lines(input_line, Term::Screen.width)
           @prompt.print(refresh(question.lines.size, total_lines))
         end
 
@@ -141,9 +141,9 @@ module Term
       def read_input(question)
         if value = @value
           @first_render = false
-          @prompt.read_line(question, echo: @echo, value: value).chomp
+          @prompt.read_line(prompt: question, echo: @echo, value: value).chomp
         else
-          @prompt.read_line(question, echo: @echo).chomp
+          @prompt.read_line(prompt: question, echo: @echo).chomp
         end
       end
 


### PR DESCRIPTION
Term::Reader was updated recently which broke this shard. This commit fixes all compile errors related to Term::Reader.