### PR TITLE
Replace Cor in the palette with Term::Color

### DIFF
--- a/src/prompt/palette.cr
+++ b/src/prompt/palette.cr
@@ -1,10 +1,10 @@
 module Term
   class Prompt
     record Palette,
-      enabled = Cor.color(:dark_grey),
-      active = Cor.color(:green),
-      help = Cor.color(:dim_grey),
-      error = Cor.color(:red),
-      warning = Cor.color(:yellow)
+      enabled = Color.color(:dark_grey),
+      active = Color.color(:green),
+      help = Color.color(:dim_grey),
+      error = Color.color(:red),
+      warning = Color.color(:yellow)
   end
 end


### PR DESCRIPTION
Hello.

This pull request replaces Cor, which is still used in src/prompt/palette.cr of crystal-term/prompt, with Term::Color.

Since Cor is no longer a dependency package, compilation fails.

Thank you.