### PR TITLE
Correct the version number to v0.3.2

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: term-prompt
-version: 0.3.1
+version: 0.3.2
 
 authors:
   - Chris Watson <chris@watzon.tech>

--- a/spec/prompt_spec.cr
+++ b/spec/prompt_spec.cr
@@ -1,9 +1,8 @@
 require "./spec_helper"
 
 describe Term::Prompt do
-  # TODO: Write tests
 
-  it "works" do
-    true.should eq(true)
+  it "has a version Number" do
+    Term::Prompt::VERSION.should match(/\d+\.\d+\.\d+/)
   end
 end

--- a/src/prompt/version.cr
+++ b/src/prompt/version.cr
@@ -1,5 +1,5 @@
 module Term
   class Prompt
-    VERSION = "0.3.1"
+    VERSION = {{ `shards version #{__DIR__}`.chomp.stringify }}
   end
 end


### PR DESCRIPTION
- Define the version number in only one place
- Added version number testing

There are mixed opinions about the macro that fetches the version from shards.yml, but I think it's better to avoid unnecessary effort.